### PR TITLE
fix username typo

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -152,7 +152,7 @@ export declare namespace TelegramWebApps {
     /**
      * Username of the user or bot.
      */
-    usernames?: string;
+    username?: string;
     /**
      * IETF language tag of the user's language. Returns in user field only.
      */


### PR DESCRIPTION
instead of usernames it should be username base on  (https://core.telegram.org/bots/webapps#webappuser)