### PR TITLE
Fix typo in index.d.ts

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -152,7 +152,7 @@ export declare namespace TelegramWebApps {
     /**
      * Username of the user or bot.
      */
-    usernames?: string;
+    username?: string;
     /**
      * IETF language tag of the user's language. Returns in user field only.
      */


### PR DESCRIPTION
Inside WebAppUser, the username field was actually called usernameS, causing problems and not allowing to query username in a type-safe way